### PR TITLE
Fixed with if statement

### DIFF
--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -97,7 +97,9 @@ class Collection {
                 }
 
                 if ($name == $recordName) {
-					$recordType = '\codelathe\fccloudapi\\'.$recordType;
+                    if (substr($recordType,0,strlen("\codelathe")) != "\codelathe" ) {
+					    $recordType = '\codelathe\fccloudapi\\'.$recordType;
+                    }
                     $this->m_records[] = new $recordType($array);
                 } else if ($meta != "" && $name == $meta) {
                     $this->m_meta = new DataRecord($array);


### PR DESCRIPTION
When building the file list, this section (on the second "Entry" $recordType) would append the namespace again and throw an error. Fixed it by checking that the record type didn't already start with /codelathe.