### PR TITLE
Add user metadata calls

### DIFF
--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -2760,6 +2760,8 @@ class APICore {
     }
 
 class CloudAPI extends APICore {
+
+    use MetadataAttributeTypeCasterTrait;
     
     public function __construct($SERVER_URL, $debug = false) {
         parent::__construct($SERVER_URL, $debug);
@@ -4708,8 +4710,6 @@ class CloudAPI extends APICore {
 
         return $record;
     }
-
-    use MetadataAttributeTypeCasterTrait;
     
     /**
      * Update attribute values of a file object's metadata

--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -238,31 +238,31 @@ trait MetadataAttributeTypeCasterTrait
     protected function guessType($data)
     {
         if ($data instanceof \DateTime) {
-            return AbstractMetadataRecord::TYPE_DATE;
+            return MetadataAttributeTypes::TYPE_DATE;
         }
         
         if (is_int($data)) {
-            return AbstractMetadataRecord::TYPE_INTEGER;
+            return MetadataAttributeTypes::TYPE_INTEGER;
         }
         
         if (is_float($data)) {
-            return AbstractMetadataRecord::TYPE_DECIMAL;
+            return MetadataAttributeTypes::TYPE_DECIMAL;
         }
         
         if (is_bool($data)) {
-            return AbstractMetadataRecord::TYPE_BOOLEAN;
+            return MetadataAttributeTypes::TYPE_BOOLEAN;
         }
         
         if (is_array($data)) {
-            return AbstractMetadataRecord::TYPE_ARRAY;
+            return MetadataAttributeTypes::TYPE_ARRAY;
         }
         
-        return AbstractMetadataRecord::TYPE_TEXT;
+        return MetadataAttributeTypes::TYPE_TEXT;
     }
 }
 
 /**
- * Class AbstractMetadataRecord
+ * Class MetadataAttributeTypes
  * @package codelathe\fccloudapi
  */
 final class MetadataAttributeTypes

--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -4659,7 +4659,7 @@ class CloudAPI extends APICore {
         $response = $this->doPOST("{$this->server_url}/core/getmetadatasetsforsearch", http_build_query([
             'fullpath' => $fullPath
         ]));
-        $collection = new Collection($response,  'metadataset', AdminMetadataSetRecord::class);
+        $collection = new Collection($response,  'metadataset', MetadataSetRecord::class);
         $this->stopTimer();
 
         return $collection;

--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -228,6 +228,37 @@ trait MetadataAttributeTypeCasterTrait
 
         return $data;
     }
+
+    /**
+     * Best effort guess of datatype
+     * 
+     * @param $data
+     * @return int
+     */
+    protected function guessType($data)
+    {
+        if ($data instanceof \DateTime) {
+            return AbstractMetadataRecord::TYPE_DATE;
+        }
+        
+        if (is_int($data)) {
+            return AbstractMetadataRecord::TYPE_INTEGER;
+        }
+        
+        if (is_float($data)) {
+            return AbstractMetadataRecord::TYPE_DECIMAL;
+        }
+        
+        if (is_bool($data)) {
+            return AbstractMetadataRecord::TYPE_BOOLEAN;
+        }
+        
+        if (is_array($data)) {
+            return AbstractMetadataRecord::TYPE_ARRAY;
+        }
+        
+        return AbstractMetadataRecord::TYPE_TEXT;
+    }
 }
 
 /**
@@ -4589,6 +4620,40 @@ class CloudAPI extends APICore {
             'fullpath' => $fullPath,
             'setid' => $setId,
         ]));
+        $collection = new Collection($response,  'command', CommandRecord::class);
+        $records = $collection->getRecords();
+        $record = $collection->getNumberOfRecords() > 0 ? reset($records) : null;
+        $this->stopTimer();
+
+        return $record;
+    }
+
+    use MetadataAttributeTypeCasterTrait;
+    
+    /**
+     * Update attribute values of a file object's metadata
+     * 
+     * @param string $setId
+     * @param string $fullPath
+     * @param array $attributes
+     * @return CommandRecord|null
+     */
+    public function saveAttributeValues(string $fullPath, string $setId, array $attributes): ?CommandRecord
+    {
+        $this->startTimer();
+        $args = [
+            'fullpath' => $fullPath,
+            'setid' => $setId,
+        ];
+        
+        foreach ($attributes as $i => $attribute) {
+            $args["attribute{$i}_attributeid"] = $attribute['attributeid'];
+            $args["attribute{$i}_value"] = $this->reverseCastFromType($attribute['value'], $this->guessType($attribute['value']));
+        }
+
+        $args['attributes_total'] = count($attributes);
+        
+        $response = $this->doPOST("{$this->server_url}/core/saveattributevalues", http_build_query($args));
         $collection = new Collection($response,  'command', CommandRecord::class);
         $records = $collection->getRecords();
         $record = $collection->getNumberOfRecords() > 0 ? reset($records) : null;

--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -4552,6 +4552,28 @@ class CloudAPI extends APICore {
 
         return $collection;
     }
+
+    /**
+     * Add specified metadata set to file object
+     * 
+     * @param string $fullPath
+     * @param string $setId
+     * @return CommandRecord|null
+     */
+    public function addSetToFileObject(string $fullPath, string $setId): ?CommandRecord
+    {
+        $this->startTimer();
+        $response = $this->doPOST("{$this->server_url}/core/addsettofileobject", http_build_query([
+            'fullpath' => $fullPath,
+            'setid' => $setId,
+        ]));
+        $collection = new Collection($response,  'command', CommandRecord::class);
+        $records = $collection->getRecords();
+        $record = $collection->getNumberOfRecords() > 0 ? reset($records) : null;
+        $this->stopTimer();
+
+        return $record;
+    }
     
     public function getUITranslations() {
         $this->startTimer();

--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -4534,6 +4534,24 @@ class CloudAPI extends APICore {
         
         return $collection;
     }
+
+    /**
+     * Get metadata sets for search
+     * 
+     * @param string $fullPath
+     * @return Collection|null
+     */
+    public function getMetadataSetsForSearch(string $fullPath): ?Collection
+    {
+        $this->startTimer();
+        $response = $this->doPOST("{$this->server_url}/core/getmetadatasetsforsearch", http_build_query([
+            'fullpath' => $fullPath
+        ]));
+        $collection = new Collection($response,  'metadataset', AdminMetadataSetRecord::class);
+        $this->stopTimer();
+
+        return $collection;
+    }
     
     public function getUITranslations() {
         $this->startTimer();

--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -4574,6 +4574,28 @@ class CloudAPI extends APICore {
 
         return $record;
     }
+
+    /**
+     * Remove specified metadata set from file object
+     * 
+     * @param string $fullPath
+     * @param string $setId
+     * @return CommandRecord|null
+     */
+    public function removeSetFromFileObject(string $fullPath, string $setId): ?CommandRecord
+    {
+        $this->startTimer();
+        $response = $this->doPOST("{$this->server_url}/core/removesetfromfileobject", http_build_query([
+            'fullpath' => $fullPath,
+            'setid' => $setId,
+        ]));
+        $collection = new Collection($response,  'command', CommandRecord::class);
+        $records = $collection->getRecords();
+        $record = $collection->getNumberOfRecords() > 0 ? reset($records) : null;
+        $this->stopTimer();
+
+        return $record;
+    }
     
     public function getUITranslations() {
         $this->startTimer();

--- a/tests/CloudApi/AddSetToFileObjectTest.php
+++ b/tests/CloudApi/AddSetToFileObjectTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace CodeLathe\FileCloudApi\Tests\CloudApi;
+
+use codelathe\fccloudapi\CloudAPI;
+use codelathe\fccloudapi\CommandRecord;
+use CodeLathe\FileCloudApi\Tests\Fixtures\AccessibleCloudApi;
+use PHPUnit\Framework\TestCase;
+
+class AddSetToFileObjectTest extends TestCase
+{
+    public function testOnSuccess()
+    {
+        $serverUrl = 'https://fcapi.example.com';
+        $cloudApiMock = $this->getMockBuilder(AccessibleCloudApi::class)
+            ->setConstructorArgs([$serverUrl])
+            ->setMethods(['init', '__destruct', 'doPost'])
+            ->getMock();
+
+        $mockApiResponse = <<<RESPONSE
+<commands>
+    <command>
+        <type>addsettofileobject</type>
+        <result>1</result>
+        <message>Metadata set (setId: 5ccafe12adccf621f80342e6) was successfully added to File Object (/tester/textfile1.txt)</message>
+    </command>
+</commands>
+RESPONSE;
+        $mockApiRequest = $this->getValidApiRequest();
+
+        $cloudApiMock->method('doPost')
+            ->with("{$serverUrl}/core/addsettofileobject", http_build_query($mockApiRequest))
+            ->willReturn($mockApiResponse);
+
+        /** @var CloudAPI $cloudApiMock */
+        /** @var CommandRecord $commandRecord */
+        $commandRecord = $cloudApiMock->addSetToFileObject(...array_values($mockApiRequest));
+        $this->assertEquals(1, $commandRecord->getResult());
+        $this->assertEquals('addsettofileobject', $commandRecord->getType());
+        $this->assertEquals(
+            "Metadata set (setId: {$mockApiRequest['setid']}) was successfully added to File Object ({$mockApiRequest['fullpath']})",
+            $commandRecord->getMessage()
+        );
+    }
+    
+    public function testOnFailure()
+    {
+        $serverUrl = 'https://fcapi.example.com';
+        $cloudApiMock = $this->getMockBuilder(AccessibleCloudApi::class)
+            ->setConstructorArgs([$serverUrl])
+            ->setMethods(['init', '__destruct', 'doPost'])
+            ->getMock();
+
+        $mockApiResponse = <<<RESPONSE
+<commands>
+    <command>
+        <type>addsettofileobject</type>
+        <result>0</result>
+        <message>Failed to bind Set Definition (setId: 5ccafe12adccf621f80342e7) to File Object (/tester/textfile1.txt). Reason: Incorrect set id provided</message>
+    </command>
+</commands>
+RESPONSE;
+        $mockApiRequest = $this->getValidApiRequest();
+        $mockApiRequest['setid'] = '5ccafe12adccf621f80342e7';    // Pretend this is an invalid id
+
+
+        $cloudApiMock->method('doPost')
+            ->with("{$serverUrl}/core/addsettofileobject", http_build_query($mockApiRequest))
+            ->willReturn($mockApiResponse);
+
+        /** @var CloudAPI $cloudApiMock */
+        /** @var CommandRecord $commandRecord */
+        $commandRecord = $cloudApiMock->addSetToFileObject(...array_values($mockApiRequest));
+        $this->assertEquals(0, $commandRecord->getResult());
+        $this->assertEquals('addsettofileobject', $commandRecord->getType());
+        $this->assertEquals(
+            "Failed to bind Set Definition (setId: {$mockApiRequest['setid']}) to File Object ({$mockApiRequest['fullpath']}). Reason: Incorrect set id provided",
+            $commandRecord->getMessage()
+        );
+    }
+    
+    private function getValidApiRequest()
+    {
+        return [
+            'fullpath' => '/tester/textfile1.txt',
+            'setid' => '5ccafe12adccf621f80342e6',
+        ];
+    }
+}

--- a/tests/CloudApi/GetMetadataForSearchTest.php
+++ b/tests/CloudApi/GetMetadataForSearchTest.php
@@ -4,6 +4,7 @@ namespace CodeLathe\FileCloudApi\Tests\CloudApi;
 
 use codelathe\fccloudapi\AdminMetadataSetRecord;
 use codelathe\fccloudapi\CloudAPI;
+use codelathe\fccloudapi\MetadataSetRecord;
 use CodeLathe\FileCloudApi\Tests\Fixtures\AccessibleCloudApi;
 use PHPUnit\Framework\TestCase;
 
@@ -31,10 +32,10 @@ class GetMetadataForSearchTest extends TestCase
         /** @var CloudAPI $cloudApiMock */
         $metadataSets = $cloudApiMock->getMetadataSetsForSearch($fullPath);
 
-        $this->assertEquals(4, $metadataSets->getNumberOfRecords());
+        $this->assertEquals(2, $metadataSets->getNumberOfRecords());
 
         foreach ($metadataSets->getRecords() as $i => $record) {
-            $this->assertInstanceOf(AdminMetadataSetRecord::class, $record);
+            $this->assertInstanceOf(MetadataSetRecord::class, $record);
         }
     }
     
@@ -43,53 +44,92 @@ class GetMetadataForSearchTest extends TestCase
         return <<<RESPONSE
 <metadatasets>
     <meta>
-        <total>4</total>
+        <total>2</total>
     </meta>
     <metadataset>
-        <id>55557777bbbbccccddddaaaa</id>
-        <name>Default</name>
-        <description>Default description</description>
-        <type>2</type>
+        <id>5ccafe12adccf621f80342e6</id>
+        <name>Sample4</name>
+        <description>Description</description>
         <disabled></disabled>
-        <allowallpaths>1</allowallpaths>
-        <attribute0_attributeid>5cba17edadccf621f8017c46</attribute0_attributeid>
-        <attribute0_name>Tags</attribute0_name>
-        <attribute0_description>Tags</attribute0_description>
-        <attribute0_type>7</attribute0_type>
-        <attribute0_defaultvalue></attribute0_defaultvalue>
+        <read>1</read>
+        <write>1</write>
+        <attribute0_attributeid>5cc82c59adccf621f8023feb</attribute0_attributeid>
+        <attribute0_name>Text</attribute0_name>
+        <attribute0_description>Description</attribute0_description>
+        <attribute0_type>1</attribute0_type>
+        <attribute0_defaultvalue>Default</attribute0_defaultvalue>
         <attribute0_required></attribute0_required>
         <attribute0_disabled></attribute0_disabled>
-        <attributes_total>1</attributes_total>
-        <users_total>0</users_total>
-        <group0_id>55557777bbbbccccddddaaaa</group0_id>
-        <group0_name>EVERYONE</group0_name>
-        <group0_read>1</group0_read>
-        <group0_write>1</group0_write>
-        <groups_total>1</groups_total>
-        <paths_total>0</paths_total>
+        <attribute1_attributeid>5cc82c59adccf621f8023fec</attribute1_attributeid>
+        <attribute1_name>Int</attribute1_name>
+        <attribute1_description>Description</attribute1_description>
+        <attribute1_type>2</attribute1_type>
+        <attribute1_defaultvalue>100</attribute1_defaultvalue>
+        <attribute1_required></attribute1_required>
+        <attribute1_disabled></attribute1_disabled>
+        <attribute2_attributeid>5cc82c59adccf621f8023fed</attribute2_attributeid>
+        <attribute2_name>Dec</attribute2_name>
+        <attribute2_description>Description</attribute2_description>
+        <attribute2_type>3</attribute2_type>
+        <attribute2_defaultvalue>1.1</attribute2_defaultvalue>
+        <attribute2_required></attribute2_required>
+        <attribute2_disabled></attribute2_disabled>
+        <attribute3_attributeid>5cc82c59adccf621f8023fee</attribute3_attributeid>
+        <attribute3_name>Bool</attribute3_name>
+        <attribute3_description>Description</attribute3_description>
+        <attribute3_type>4</attribute3_type>
+        <attribute3_defaultvalue>false</attribute3_defaultvalue>
+        <attribute3_required></attribute3_required>
+        <attribute3_disabled></attribute3_disabled>
+        <attribute4_attributeid>5cc82c59adccf621f8023fef</attribute4_attributeid>
+        <attribute4_name>Date</attribute4_name>
+        <attribute4_description>Description</attribute4_description>
+        <attribute4_type>5</attribute4_type>
+        <attribute4_defaultvalue>2019-04-03 00:00:00</attribute4_defaultvalue>
+        <attribute4_required></attribute4_required>
+        <attribute4_disabled></attribute4_disabled>
+        <attribute5_attributeid>5cc82c59adccf621f8023ff0</attribute5_attributeid>
+        <attribute5_name>Select</attribute5_name>
+        <attribute5_description>Description</attribute5_description>
+        <attribute5_type>6</attribute5_type>
+        <attribute5_defaultvalue>foo</attribute5_defaultvalue>
+        <attribute5_required></attribute5_required>
+        <attribute5_disabled></attribute5_disabled>
+        <attribute5_predefinedvalue0>foo</attribute5_predefinedvalue0>
+        <attribute5_predefinedvalue1>bar</attribute5_predefinedvalue1>
+        <attribute5_predefinedvalue2>baz</attribute5_predefinedvalue2>
+        <attribute5_predefinedvalues_total>3</attribute5_predefinedvalues_total>
+        <attribute6_attributeid>5cc82c59adccf621f8023ff1</attribute6_attributeid>
+        <attribute6_name>MultiSelect</attribute6_name>
+        <attribute6_description>Description</attribute6_description>
+        <attribute6_type>7</attribute6_type>
+        <attribute6_defaultvalue>a,b,c,d</attribute6_defaultvalue>
+        <attribute6_required></attribute6_required>
+        <attribute6_disabled></attribute6_disabled>
+        <attributes_total>7</attributes_total>
     </metadataset>
     <metadataset>
         <id>55557777bbbbccccddddaaab</id>
         <name>Image metadata</name>
         <description>Image metadata (EXIF)</description>
-        <type>1</type>
         <disabled></disabled>
-        <allowallpaths>1</allowallpaths>
-        <attribute0_attributeid>5cc05ea6adccf621f80216e4</attribute0_attributeid>
+        <read>1</read>
+        <write></write>
+        <attribute0_attributeid>5cd02a81adccf61c6c004ce0</attribute0_attributeid>
         <attribute0_name>Width</attribute0_name>
         <attribute0_description>Image Width in Pixels</attribute0_description>
         <attribute0_type>2</attribute0_type>
         <attribute0_defaultvalue></attribute0_defaultvalue>
         <attribute0_required></attribute0_required>
         <attribute0_disabled></attribute0_disabled>
-        <attribute1_attributeid>5cc05ea6adccf621f80216e5</attribute1_attributeid>
+        <attribute1_attributeid>5cd02a81adccf61c6c004ce1</attribute1_attributeid>
         <attribute1_name>Height</attribute1_name>
         <attribute1_description>Image Height in Pixels</attribute1_description>
         <attribute1_type>2</attribute1_type>
         <attribute1_defaultvalue></attribute1_defaultvalue>
         <attribute1_required></attribute1_required>
         <attribute1_disabled></attribute1_disabled>
-        <attribute2_attributeid>5cc05ea6adccf621f80216e6</attribute2_attributeid>
+        <attribute2_attributeid>5cd02a81adccf61c6c004ce2</attribute2_attributeid>
         <attribute2_name>Image Orientation</attribute2_name>
         <attribute2_description>Image orientation</attribute2_description>
         <attribute2_type>6</attribute2_type>
@@ -99,28 +139,28 @@ class GetMetadataForSearchTest extends TestCase
         <attribute2_predefinedvalue0>Horizontal</attribute2_predefinedvalue0>
         <attribute2_predefinedvalue1>Vertical</attribute2_predefinedvalue1>
         <attribute2_predefinedvalues_total>2</attribute2_predefinedvalues_total>
-        <attribute3_attributeid>5cc05ea6adccf621f80216e7</attribute3_attributeid>
+        <attribute3_attributeid>5cd02a81adccf61c6c004ce3</attribute3_attributeid>
         <attribute3_name>Image Orientation - Numeric</attribute3_name>
         <attribute3_description>Image orientation as a number (8 different orientations)</attribute3_description>
         <attribute3_type>2</attribute3_type>
         <attribute3_defaultvalue></attribute3_defaultvalue>
         <attribute3_required></attribute3_required>
         <attribute3_disabled></attribute3_disabled>
-        <attribute4_attributeid>5cc05ea6adccf621f80216e8</attribute4_attributeid>
+        <attribute4_attributeid>5cd02a81adccf61c6c004ce4</attribute4_attributeid>
         <attribute4_name>Image XResolution</attribute4_name>
         <attribute4_description>Image Resolution in width direction</attribute4_description>
         <attribute4_type>1</attribute4_type>
         <attribute4_defaultvalue></attribute4_defaultvalue>
         <attribute4_required></attribute4_required>
         <attribute4_disabled></attribute4_disabled>
-        <attribute5_attributeid>5cc05ea6adccf621f80216e9</attribute5_attributeid>
+        <attribute5_attributeid>5cd02a81adccf61c6c004ce5</attribute5_attributeid>
         <attribute5_name>Image YResolution</attribute5_name>
         <attribute5_description>Image Resolution in height direction</attribute5_description>
         <attribute5_type>1</attribute5_type>
         <attribute5_defaultvalue></attribute5_defaultvalue>
         <attribute5_required></attribute5_required>
         <attribute5_disabled></attribute5_disabled>
-        <attribute6_attributeid>5cc05ea6adccf621f80216ea</attribute6_attributeid>
+        <attribute6_attributeid>5cd02a81adccf61c6c004ce6</attribute6_attributeid>
         <attribute6_name>Unit of Resolution</attribute6_name>
         <attribute6_description>Unit of resolution</attribute6_description>
         <attribute6_type>6</attribute6_type>
@@ -131,98 +171,98 @@ class GetMetadataForSearchTest extends TestCase
         <attribute6_predefinedvalue1>in</attribute6_predefinedvalue1>
         <attribute6_predefinedvalue2>cm</attribute6_predefinedvalue2>
         <attribute6_predefinedvalues_total>3</attribute6_predefinedvalues_total>
-        <attribute7_attributeid>5cc05ea6adccf621f80216eb</attribute7_attributeid>
+        <attribute7_attributeid>5cd02a81adccf61c6c004ce7</attribute7_attributeid>
         <attribute7_name>Image Creation Date</attribute7_name>
         <attribute7_description>Date of image creation. Date when photo was actually taken.</attribute7_description>
         <attribute7_type>5</attribute7_type>
         <attribute7_defaultvalue></attribute7_defaultvalue>
         <attribute7_required></attribute7_required>
         <attribute7_disabled></attribute7_disabled>
-        <attribute8_attributeid>5cc05ea6adccf621f80216ec</attribute8_attributeid>
+        <attribute8_attributeid>5cd02a81adccf61c6c004ce8</attribute8_attributeid>
         <attribute8_name>Make</attribute8_name>
         <attribute8_description>Camera Make (manufacturer)</attribute8_description>
         <attribute8_type>1</attribute8_type>
         <attribute8_defaultvalue></attribute8_defaultvalue>
         <attribute8_required></attribute8_required>
         <attribute8_disabled></attribute8_disabled>
-        <attribute9_attributeid>5cc05ea6adccf621f80216ed</attribute9_attributeid>
+        <attribute9_attributeid>5cd02a81adccf61c6c004ce9</attribute9_attributeid>
         <attribute9_name>Model</attribute9_name>
         <attribute9_description>Camera Model</attribute9_description>
         <attribute9_type>1</attribute9_type>
         <attribute9_defaultvalue></attribute9_defaultvalue>
         <attribute9_required></attribute9_required>
         <attribute9_disabled></attribute9_disabled>
-        <attribute10_attributeid>5cc05ea6adccf621f80216ee</attribute10_attributeid>
+        <attribute10_attributeid>5cd02a81adccf61c6c004cea</attribute10_attributeid>
         <attribute10_name>Artist</attribute10_name>
         <attribute10_description>Artist</attribute10_description>
         <attribute10_type>1</attribute10_type>
         <attribute10_defaultvalue></attribute10_defaultvalue>
         <attribute10_required></attribute10_required>
         <attribute10_disabled></attribute10_disabled>
-        <attribute11_attributeid>5cc05ea6adccf621f80216ef</attribute11_attributeid>
+        <attribute11_attributeid>5cd02a81adccf61c6c004ceb</attribute11_attributeid>
         <attribute11_name>Copyright</attribute11_name>
         <attribute11_description>Copyright</attribute11_description>
         <attribute11_type>1</attribute11_type>
         <attribute11_defaultvalue></attribute11_defaultvalue>
         <attribute11_required></attribute11_required>
         <attribute11_disabled></attribute11_disabled>
-        <attribute12_attributeid>5cc05ea6adccf621f80216f0</attribute12_attributeid>
+        <attribute12_attributeid>5cd02a81adccf61c6c004cec</attribute12_attributeid>
         <attribute12_name>Software</attribute12_name>
         <attribute12_description>Software used for the last image edit</attribute12_description>
         <attribute12_type>1</attribute12_type>
         <attribute12_defaultvalue></attribute12_defaultvalue>
         <attribute12_required></attribute12_required>
         <attribute12_disabled></attribute12_disabled>
-        <attribute13_attributeid>5cc05ea6adccf621f80216f1</attribute13_attributeid>
+        <attribute13_attributeid>5cd02a81adccf61c6c004ced</attribute13_attributeid>
         <attribute13_name>Exposure Time</attribute13_name>
         <attribute13_description>Copyright</attribute13_description>
         <attribute13_type>1</attribute13_type>
         <attribute13_defaultvalue></attribute13_defaultvalue>
         <attribute13_required></attribute13_required>
         <attribute13_disabled></attribute13_disabled>
-        <attribute14_attributeid>5cc05ea6adccf621f80216f2</attribute14_attributeid>
+        <attribute14_attributeid>5cd02a81adccf61c6c004cee</attribute14_attributeid>
         <attribute14_name>FNumber</attribute14_name>
         <attribute14_description>FNumber</attribute14_description>
         <attribute14_type>1</attribute14_type>
         <attribute14_defaultvalue></attribute14_defaultvalue>
         <attribute14_required></attribute14_required>
         <attribute14_disabled></attribute14_disabled>
-        <attribute15_attributeid>5cc05ea6adccf621f80216f3</attribute15_attributeid>
+        <attribute15_attributeid>5cd02a81adccf61c6c004cef</attribute15_attributeid>
         <attribute15_name>ISO</attribute15_name>
         <attribute15_description>ISO</attribute15_description>
         <attribute15_type>1</attribute15_type>
         <attribute15_defaultvalue></attribute15_defaultvalue>
         <attribute15_required></attribute15_required>
         <attribute15_disabled></attribute15_disabled>
-        <attribute16_attributeid>5cc05ea6adccf621f80216f4</attribute16_attributeid>
+        <attribute16_attributeid>5cd02a81adccf61c6c004cf0</attribute16_attributeid>
         <attribute16_name>Exif Version</attribute16_name>
         <attribute16_description>Exif version used</attribute16_description>
         <attribute16_type>1</attribute16_type>
         <attribute16_defaultvalue></attribute16_defaultvalue>
         <attribute16_required></attribute16_required>
         <attribute16_disabled></attribute16_disabled>
-        <attribute17_attributeid>5cc05ea6adccf621f80216f5</attribute17_attributeid>
+        <attribute17_attributeid>5cd02a81adccf61c6c004cf1</attribute17_attributeid>
         <attribute17_name>Shutter Speed</attribute17_name>
         <attribute17_description>The shutter speed</attribute17_description>
         <attribute17_type>1</attribute17_type>
         <attribute17_defaultvalue></attribute17_defaultvalue>
         <attribute17_required></attribute17_required>
         <attribute17_disabled></attribute17_disabled>
-        <attribute18_attributeid>5cc05ea6adccf621f80216f6</attribute18_attributeid>
+        <attribute18_attributeid>5cd02a81adccf61c6c004cf2</attribute18_attributeid>
         <attribute18_name>Aperture</attribute18_name>
         <attribute18_description>Aperture values</attribute18_description>
         <attribute18_type>1</attribute18_type>
         <attribute18_defaultvalue></attribute18_defaultvalue>
         <attribute18_required></attribute18_required>
         <attribute18_disabled></attribute18_disabled>
-        <attribute19_attributeid>5cc05ea6adccf621f80216f7</attribute19_attributeid>
+        <attribute19_attributeid>5cd02a81adccf61c6c004cf3</attribute19_attributeid>
         <attribute19_name>Brightness</attribute19_name>
         <attribute19_description>Brightness</attribute19_description>
         <attribute19_type>1</attribute19_type>
         <attribute19_defaultvalue></attribute19_defaultvalue>
         <attribute19_required></attribute19_required>
         <attribute19_disabled></attribute19_disabled>
-        <attribute20_attributeid>5cc05ea6adccf621f80216f8</attribute20_attributeid>
+        <attribute20_attributeid>5cd02a81adccf61c6c004cf4</attribute20_attributeid>
         <attribute20_name>Focal Length</attribute20_name>
         <attribute20_description>Focal Length</attribute20_description>
         <attribute20_type>1</attribute20_type>
@@ -230,126 +270,6 @@ class GetMetadataForSearchTest extends TestCase
         <attribute20_required></attribute20_required>
         <attribute20_disabled></attribute20_disabled>
         <attributes_total>21</attributes_total>
-        <users_total>0</users_total>
-        <group0_id>55557777bbbbccccddddaaaa</group0_id>
-        <group0_name>EVERYONE</group0_name>
-        <group0_read>1</group0_read>
-        <group0_write></group0_write>
-        <groups_total>1</groups_total>
-        <paths_total>0</paths_total>
-    </metadataset>
-    <metadataset>
-        <id>55557777bbbbccccddddaaac</id>
-        <name>Document Life Cycle metadata</name>
-        <description>Stores information regarding document life cycle</description>
-        <type>1</type>
-        <disabled></disabled>
-        <allowallpaths>1</allowallpaths>
-        <attribute0_attributeid>5cc05ea6adccf621f80216f9</attribute0_attributeid>
-        <attribute0_name>Creation Date</attribute0_name>
-        <attribute0_description>File/Folder creation date</attribute0_description>
-        <attribute0_type>5</attribute0_type>
-        <attribute0_defaultvalue></attribute0_defaultvalue>
-        <attribute0_required></attribute0_required>
-        <attribute0_disabled></attribute0_disabled>
-        <attribute1_attributeid>5cc05ea6adccf621f80216fa</attribute1_attributeid>
-        <attribute1_name>Last Access</attribute1_name>
-        <attribute1_description>Last access date</attribute1_description>
-        <attribute1_type>5</attribute1_type>
-        <attribute1_defaultvalue></attribute1_defaultvalue>
-        <attribute1_required></attribute1_required>
-        <attribute1_disabled></attribute1_disabled>
-        <attribute2_attributeid>5cc05ea6adccf621f80216fb</attribute2_attributeid>
-        <attribute2_name>Last Modification</attribute2_name>
-        <attribute2_description>Last modification date</attribute2_description>
-        <attribute2_type>5</attribute2_type>
-        <attribute2_defaultvalue></attribute2_defaultvalue>
-        <attribute2_required></attribute2_required>
-        <attribute2_disabled></attribute2_disabled>
-        <attribute3_attributeid>5cc05ea6adccf621f80216fc</attribute3_attributeid>
-        <attribute3_name>Check Sum</attribute3_name>
-        <attribute3_description>File SHA256 fingerprint</attribute3_description>
-        <attribute3_type>1</attribute3_type>
-        <attribute3_defaultvalue></attribute3_defaultvalue>
-        <attribute3_required></attribute3_required>
-        <attribute3_disabled></attribute3_disabled>
-        <attributes_total>4</attributes_total>
-        <users_total>0</users_total>
-        <groups_total>0</groups_total>
-        <paths_total>0</paths_total>
-    </metadataset>
-    <metadataset>
-        <id>5cc06b9fadccf621f80217d0</id>
-        <name>Review</name>
-        <description>Review description</description>
-        <type>3</type>
-        <disabled></disabled>
-        <allowallpaths></allowallpaths>
-        <attribute0_attributeid>5cc06b9fadccf621f80217ce</attribute0_attributeid>
-        <attribute0_name>String</attribute0_name>
-        <attribute0_description>String description</attribute0_description>
-        <attribute0_type>1</attribute0_type>
-        <attribute0_defaultvalue>Default string</attribute0_defaultvalue>
-        <attribute0_required>1</attribute0_required>
-        <attribute0_disabled></attribute0_disabled>
-        <attribute1_attributeid>5cc09402adccf621f8021956</attribute1_attributeid>
-        <attribute1_name>Int</attribute1_name>
-        <attribute1_description></attribute1_description>
-        <attribute1_type>2</attribute1_type>
-        <attribute1_defaultvalue>1000</attribute1_defaultvalue>
-        <attribute1_required>1</attribute1_required>
-        <attribute1_disabled></attribute1_disabled>
-        <attribute2_attributeid>5cc09402adccf621f8021957</attribute2_attributeid>
-        <attribute2_name>Dec</attribute2_name>
-        <attribute2_description></attribute2_description>
-        <attribute2_type>3</attribute2_type>
-        <attribute2_defaultvalue>1.1</attribute2_defaultvalue>
-        <attribute2_required></attribute2_required>
-        <attribute2_disabled></attribute2_disabled>
-        <attribute3_attributeid>5cc09402adccf621f8021958</attribute3_attributeid>
-        <attribute3_name>Bool</attribute3_name>
-        <attribute3_description></attribute3_description>
-        <attribute3_type>4</attribute3_type>
-        <attribute3_defaultvalue>true</attribute3_defaultvalue>
-        <attribute3_required></attribute3_required>
-        <attribute3_disabled></attribute3_disabled>
-        <attribute4_attributeid>5cc09402adccf621f8021959</attribute4_attributeid>
-        <attribute4_name>Date</attribute4_name>
-        <attribute4_description></attribute4_description>
-        <attribute4_type>5</attribute4_type>
-        <attribute4_defaultvalue>2019-04-03 00:00:00</attribute4_defaultvalue>
-        <attribute4_required></attribute4_required>
-        <attribute4_disabled></attribute4_disabled>
-        <attribute5_attributeid>5cc09402adccf621f802195a</attribute5_attributeid>
-        <attribute5_name>Select</attribute5_name>
-        <attribute5_description></attribute5_description>
-        <attribute5_type>6</attribute5_type>
-        <attribute5_defaultvalue>A</attribute5_defaultvalue>
-        <attribute5_required></attribute5_required>
-        <attribute5_disabled></attribute5_disabled>
-        <attribute5_predefinedvalue0>A</attribute5_predefinedvalue0>
-        <attribute5_predefinedvalue1>B</attribute5_predefinedvalue1>
-        <attribute5_predefinedvalue2>C</attribute5_predefinedvalue2>
-        <attribute5_predefinedvalues_total>3</attribute5_predefinedvalues_total>
-        <attribute6_attributeid>5cc09402adccf621f802195b</attribute6_attributeid>
-        <attribute6_name>Array</attribute6_name>
-        <attribute6_description></attribute6_description>
-        <attribute6_type>7</attribute6_type>
-        <attribute6_defaultvalue>a,b,c,d</attribute6_defaultvalue>
-        <attribute6_required></attribute6_required>
-        <attribute6_disabled></attribute6_disabled>
-        <attributes_total>7</attributes_total>
-        <user0_name>user1</user0_name>
-        <user0_read>1</user0_read>
-        <user0_write>1</user0_write>
-        <users_total>1</users_total>
-        <group0_id>55557777bbbbccccddddaaaa</group0_id>
-        <group0_name>EVERYONE</group0_name>
-        <group0_read>1</group0_read>
-        <group0_write>1</group0_write>
-        <groups_total>1</groups_total>
-        <path0>/user1</path0>
-        <paths_total>1</paths_total>
     </metadataset>
 </metadatasets>
 RESPONSE;

--- a/tests/CloudApi/GetMetadataForSearchTest.php
+++ b/tests/CloudApi/GetMetadataForSearchTest.php
@@ -1,0 +1,358 @@
+<?php
+
+namespace CodeLathe\FileCloudApi\Tests\CloudApi;
+
+use codelathe\fccloudapi\AdminMetadataSetRecord;
+use codelathe\fccloudapi\CloudAPI;
+use CodeLathe\FileCloudApi\Tests\Fixtures\AccessibleCloudApi;
+use PHPUnit\Framework\TestCase;
+
+class GetMetadataForSearchTest extends TestCase
+{
+    public function testGetMetadataSetsForSearch()
+    {
+        $serverUrl = 'https://fcapi.example.com';
+        $cloudApiMock = $this->getMockBuilder(AccessibleCloudApi::class)
+            ->setConstructorArgs([$serverUrl])
+            ->setMethods(['init', '__destruct', 'doPost'])
+            ->getMock();
+
+        $mockApiResponse = $this->getSampleResponse();
+
+        $fullPath = '/tester';
+        $cloudApiMock
+            ->expects($this->any())
+            ->method('doPost')
+            ->with("$serverUrl/core/getmetadatasetsforsearch", http_build_query([
+                'fullpath' => $fullPath,
+            ]))
+            ->willReturn($mockApiResponse);
+
+        /** @var CloudAPI $cloudApiMock */
+        $metadataSets = $cloudApiMock->getMetadataSetsForSearch($fullPath);
+
+        $this->assertEquals(4, $metadataSets->getNumberOfRecords());
+
+        foreach ($metadataSets->getRecords() as $i => $record) {
+            $this->assertInstanceOf(AdminMetadataSetRecord::class, $record);
+        }
+    }
+    
+    private function getSampleResponse()
+    {
+        return <<<RESPONSE
+<metadatasets>
+    <meta>
+        <total>4</total>
+    </meta>
+    <metadataset>
+        <id>55557777bbbbccccddddaaaa</id>
+        <name>Default</name>
+        <description>Default description</description>
+        <type>2</type>
+        <disabled></disabled>
+        <allowallpaths>1</allowallpaths>
+        <attribute0_attributeid>5cba17edadccf621f8017c46</attribute0_attributeid>
+        <attribute0_name>Tags</attribute0_name>
+        <attribute0_description>Tags</attribute0_description>
+        <attribute0_type>7</attribute0_type>
+        <attribute0_defaultvalue></attribute0_defaultvalue>
+        <attribute0_required></attribute0_required>
+        <attribute0_disabled></attribute0_disabled>
+        <attributes_total>1</attributes_total>
+        <users_total>0</users_total>
+        <group0_id>55557777bbbbccccddddaaaa</group0_id>
+        <group0_name>EVERYONE</group0_name>
+        <group0_read>1</group0_read>
+        <group0_write>1</group0_write>
+        <groups_total>1</groups_total>
+        <paths_total>0</paths_total>
+    </metadataset>
+    <metadataset>
+        <id>55557777bbbbccccddddaaab</id>
+        <name>Image metadata</name>
+        <description>Image metadata (EXIF)</description>
+        <type>1</type>
+        <disabled></disabled>
+        <allowallpaths>1</allowallpaths>
+        <attribute0_attributeid>5cc05ea6adccf621f80216e4</attribute0_attributeid>
+        <attribute0_name>Width</attribute0_name>
+        <attribute0_description>Image Width in Pixels</attribute0_description>
+        <attribute0_type>2</attribute0_type>
+        <attribute0_defaultvalue></attribute0_defaultvalue>
+        <attribute0_required></attribute0_required>
+        <attribute0_disabled></attribute0_disabled>
+        <attribute1_attributeid>5cc05ea6adccf621f80216e5</attribute1_attributeid>
+        <attribute1_name>Height</attribute1_name>
+        <attribute1_description>Image Height in Pixels</attribute1_description>
+        <attribute1_type>2</attribute1_type>
+        <attribute1_defaultvalue></attribute1_defaultvalue>
+        <attribute1_required></attribute1_required>
+        <attribute1_disabled></attribute1_disabled>
+        <attribute2_attributeid>5cc05ea6adccf621f80216e6</attribute2_attributeid>
+        <attribute2_name>Image Orientation</attribute2_name>
+        <attribute2_description>Image orientation</attribute2_description>
+        <attribute2_type>6</attribute2_type>
+        <attribute2_defaultvalue></attribute2_defaultvalue>
+        <attribute2_required></attribute2_required>
+        <attribute2_disabled></attribute2_disabled>
+        <attribute2_predefinedvalue0>Horizontal</attribute2_predefinedvalue0>
+        <attribute2_predefinedvalue1>Vertical</attribute2_predefinedvalue1>
+        <attribute2_predefinedvalues_total>2</attribute2_predefinedvalues_total>
+        <attribute3_attributeid>5cc05ea6adccf621f80216e7</attribute3_attributeid>
+        <attribute3_name>Image Orientation - Numeric</attribute3_name>
+        <attribute3_description>Image orientation as a number (8 different orientations)</attribute3_description>
+        <attribute3_type>2</attribute3_type>
+        <attribute3_defaultvalue></attribute3_defaultvalue>
+        <attribute3_required></attribute3_required>
+        <attribute3_disabled></attribute3_disabled>
+        <attribute4_attributeid>5cc05ea6adccf621f80216e8</attribute4_attributeid>
+        <attribute4_name>Image XResolution</attribute4_name>
+        <attribute4_description>Image Resolution in width direction</attribute4_description>
+        <attribute4_type>1</attribute4_type>
+        <attribute4_defaultvalue></attribute4_defaultvalue>
+        <attribute4_required></attribute4_required>
+        <attribute4_disabled></attribute4_disabled>
+        <attribute5_attributeid>5cc05ea6adccf621f80216e9</attribute5_attributeid>
+        <attribute5_name>Image YResolution</attribute5_name>
+        <attribute5_description>Image Resolution in height direction</attribute5_description>
+        <attribute5_type>1</attribute5_type>
+        <attribute5_defaultvalue></attribute5_defaultvalue>
+        <attribute5_required></attribute5_required>
+        <attribute5_disabled></attribute5_disabled>
+        <attribute6_attributeid>5cc05ea6adccf621f80216ea</attribute6_attributeid>
+        <attribute6_name>Unit of Resolution</attribute6_name>
+        <attribute6_description>Unit of resolution</attribute6_description>
+        <attribute6_type>6</attribute6_type>
+        <attribute6_defaultvalue></attribute6_defaultvalue>
+        <attribute6_required></attribute6_required>
+        <attribute6_disabled></attribute6_disabled>
+        <attribute6_predefinedvalue0>NaN</attribute6_predefinedvalue0>
+        <attribute6_predefinedvalue1>in</attribute6_predefinedvalue1>
+        <attribute6_predefinedvalue2>cm</attribute6_predefinedvalue2>
+        <attribute6_predefinedvalues_total>3</attribute6_predefinedvalues_total>
+        <attribute7_attributeid>5cc05ea6adccf621f80216eb</attribute7_attributeid>
+        <attribute7_name>Image Creation Date</attribute7_name>
+        <attribute7_description>Date of image creation. Date when photo was actually taken.</attribute7_description>
+        <attribute7_type>5</attribute7_type>
+        <attribute7_defaultvalue></attribute7_defaultvalue>
+        <attribute7_required></attribute7_required>
+        <attribute7_disabled></attribute7_disabled>
+        <attribute8_attributeid>5cc05ea6adccf621f80216ec</attribute8_attributeid>
+        <attribute8_name>Make</attribute8_name>
+        <attribute8_description>Camera Make (manufacturer)</attribute8_description>
+        <attribute8_type>1</attribute8_type>
+        <attribute8_defaultvalue></attribute8_defaultvalue>
+        <attribute8_required></attribute8_required>
+        <attribute8_disabled></attribute8_disabled>
+        <attribute9_attributeid>5cc05ea6adccf621f80216ed</attribute9_attributeid>
+        <attribute9_name>Model</attribute9_name>
+        <attribute9_description>Camera Model</attribute9_description>
+        <attribute9_type>1</attribute9_type>
+        <attribute9_defaultvalue></attribute9_defaultvalue>
+        <attribute9_required></attribute9_required>
+        <attribute9_disabled></attribute9_disabled>
+        <attribute10_attributeid>5cc05ea6adccf621f80216ee</attribute10_attributeid>
+        <attribute10_name>Artist</attribute10_name>
+        <attribute10_description>Artist</attribute10_description>
+        <attribute10_type>1</attribute10_type>
+        <attribute10_defaultvalue></attribute10_defaultvalue>
+        <attribute10_required></attribute10_required>
+        <attribute10_disabled></attribute10_disabled>
+        <attribute11_attributeid>5cc05ea6adccf621f80216ef</attribute11_attributeid>
+        <attribute11_name>Copyright</attribute11_name>
+        <attribute11_description>Copyright</attribute11_description>
+        <attribute11_type>1</attribute11_type>
+        <attribute11_defaultvalue></attribute11_defaultvalue>
+        <attribute11_required></attribute11_required>
+        <attribute11_disabled></attribute11_disabled>
+        <attribute12_attributeid>5cc05ea6adccf621f80216f0</attribute12_attributeid>
+        <attribute12_name>Software</attribute12_name>
+        <attribute12_description>Software used for the last image edit</attribute12_description>
+        <attribute12_type>1</attribute12_type>
+        <attribute12_defaultvalue></attribute12_defaultvalue>
+        <attribute12_required></attribute12_required>
+        <attribute12_disabled></attribute12_disabled>
+        <attribute13_attributeid>5cc05ea6adccf621f80216f1</attribute13_attributeid>
+        <attribute13_name>Exposure Time</attribute13_name>
+        <attribute13_description>Copyright</attribute13_description>
+        <attribute13_type>1</attribute13_type>
+        <attribute13_defaultvalue></attribute13_defaultvalue>
+        <attribute13_required></attribute13_required>
+        <attribute13_disabled></attribute13_disabled>
+        <attribute14_attributeid>5cc05ea6adccf621f80216f2</attribute14_attributeid>
+        <attribute14_name>FNumber</attribute14_name>
+        <attribute14_description>FNumber</attribute14_description>
+        <attribute14_type>1</attribute14_type>
+        <attribute14_defaultvalue></attribute14_defaultvalue>
+        <attribute14_required></attribute14_required>
+        <attribute14_disabled></attribute14_disabled>
+        <attribute15_attributeid>5cc05ea6adccf621f80216f3</attribute15_attributeid>
+        <attribute15_name>ISO</attribute15_name>
+        <attribute15_description>ISO</attribute15_description>
+        <attribute15_type>1</attribute15_type>
+        <attribute15_defaultvalue></attribute15_defaultvalue>
+        <attribute15_required></attribute15_required>
+        <attribute15_disabled></attribute15_disabled>
+        <attribute16_attributeid>5cc05ea6adccf621f80216f4</attribute16_attributeid>
+        <attribute16_name>Exif Version</attribute16_name>
+        <attribute16_description>Exif version used</attribute16_description>
+        <attribute16_type>1</attribute16_type>
+        <attribute16_defaultvalue></attribute16_defaultvalue>
+        <attribute16_required></attribute16_required>
+        <attribute16_disabled></attribute16_disabled>
+        <attribute17_attributeid>5cc05ea6adccf621f80216f5</attribute17_attributeid>
+        <attribute17_name>Shutter Speed</attribute17_name>
+        <attribute17_description>The shutter speed</attribute17_description>
+        <attribute17_type>1</attribute17_type>
+        <attribute17_defaultvalue></attribute17_defaultvalue>
+        <attribute17_required></attribute17_required>
+        <attribute17_disabled></attribute17_disabled>
+        <attribute18_attributeid>5cc05ea6adccf621f80216f6</attribute18_attributeid>
+        <attribute18_name>Aperture</attribute18_name>
+        <attribute18_description>Aperture values</attribute18_description>
+        <attribute18_type>1</attribute18_type>
+        <attribute18_defaultvalue></attribute18_defaultvalue>
+        <attribute18_required></attribute18_required>
+        <attribute18_disabled></attribute18_disabled>
+        <attribute19_attributeid>5cc05ea6adccf621f80216f7</attribute19_attributeid>
+        <attribute19_name>Brightness</attribute19_name>
+        <attribute19_description>Brightness</attribute19_description>
+        <attribute19_type>1</attribute19_type>
+        <attribute19_defaultvalue></attribute19_defaultvalue>
+        <attribute19_required></attribute19_required>
+        <attribute19_disabled></attribute19_disabled>
+        <attribute20_attributeid>5cc05ea6adccf621f80216f8</attribute20_attributeid>
+        <attribute20_name>Focal Length</attribute20_name>
+        <attribute20_description>Focal Length</attribute20_description>
+        <attribute20_type>1</attribute20_type>
+        <attribute20_defaultvalue></attribute20_defaultvalue>
+        <attribute20_required></attribute20_required>
+        <attribute20_disabled></attribute20_disabled>
+        <attributes_total>21</attributes_total>
+        <users_total>0</users_total>
+        <group0_id>55557777bbbbccccddddaaaa</group0_id>
+        <group0_name>EVERYONE</group0_name>
+        <group0_read>1</group0_read>
+        <group0_write></group0_write>
+        <groups_total>1</groups_total>
+        <paths_total>0</paths_total>
+    </metadataset>
+    <metadataset>
+        <id>55557777bbbbccccddddaaac</id>
+        <name>Document Life Cycle metadata</name>
+        <description>Stores information regarding document life cycle</description>
+        <type>1</type>
+        <disabled></disabled>
+        <allowallpaths>1</allowallpaths>
+        <attribute0_attributeid>5cc05ea6adccf621f80216f9</attribute0_attributeid>
+        <attribute0_name>Creation Date</attribute0_name>
+        <attribute0_description>File/Folder creation date</attribute0_description>
+        <attribute0_type>5</attribute0_type>
+        <attribute0_defaultvalue></attribute0_defaultvalue>
+        <attribute0_required></attribute0_required>
+        <attribute0_disabled></attribute0_disabled>
+        <attribute1_attributeid>5cc05ea6adccf621f80216fa</attribute1_attributeid>
+        <attribute1_name>Last Access</attribute1_name>
+        <attribute1_description>Last access date</attribute1_description>
+        <attribute1_type>5</attribute1_type>
+        <attribute1_defaultvalue></attribute1_defaultvalue>
+        <attribute1_required></attribute1_required>
+        <attribute1_disabled></attribute1_disabled>
+        <attribute2_attributeid>5cc05ea6adccf621f80216fb</attribute2_attributeid>
+        <attribute2_name>Last Modification</attribute2_name>
+        <attribute2_description>Last modification date</attribute2_description>
+        <attribute2_type>5</attribute2_type>
+        <attribute2_defaultvalue></attribute2_defaultvalue>
+        <attribute2_required></attribute2_required>
+        <attribute2_disabled></attribute2_disabled>
+        <attribute3_attributeid>5cc05ea6adccf621f80216fc</attribute3_attributeid>
+        <attribute3_name>Check Sum</attribute3_name>
+        <attribute3_description>File SHA256 fingerprint</attribute3_description>
+        <attribute3_type>1</attribute3_type>
+        <attribute3_defaultvalue></attribute3_defaultvalue>
+        <attribute3_required></attribute3_required>
+        <attribute3_disabled></attribute3_disabled>
+        <attributes_total>4</attributes_total>
+        <users_total>0</users_total>
+        <groups_total>0</groups_total>
+        <paths_total>0</paths_total>
+    </metadataset>
+    <metadataset>
+        <id>5cc06b9fadccf621f80217d0</id>
+        <name>Review</name>
+        <description>Review description</description>
+        <type>3</type>
+        <disabled></disabled>
+        <allowallpaths></allowallpaths>
+        <attribute0_attributeid>5cc06b9fadccf621f80217ce</attribute0_attributeid>
+        <attribute0_name>String</attribute0_name>
+        <attribute0_description>String description</attribute0_description>
+        <attribute0_type>1</attribute0_type>
+        <attribute0_defaultvalue>Default string</attribute0_defaultvalue>
+        <attribute0_required>1</attribute0_required>
+        <attribute0_disabled></attribute0_disabled>
+        <attribute1_attributeid>5cc09402adccf621f8021956</attribute1_attributeid>
+        <attribute1_name>Int</attribute1_name>
+        <attribute1_description></attribute1_description>
+        <attribute1_type>2</attribute1_type>
+        <attribute1_defaultvalue>1000</attribute1_defaultvalue>
+        <attribute1_required>1</attribute1_required>
+        <attribute1_disabled></attribute1_disabled>
+        <attribute2_attributeid>5cc09402adccf621f8021957</attribute2_attributeid>
+        <attribute2_name>Dec</attribute2_name>
+        <attribute2_description></attribute2_description>
+        <attribute2_type>3</attribute2_type>
+        <attribute2_defaultvalue>1.1</attribute2_defaultvalue>
+        <attribute2_required></attribute2_required>
+        <attribute2_disabled></attribute2_disabled>
+        <attribute3_attributeid>5cc09402adccf621f8021958</attribute3_attributeid>
+        <attribute3_name>Bool</attribute3_name>
+        <attribute3_description></attribute3_description>
+        <attribute3_type>4</attribute3_type>
+        <attribute3_defaultvalue>true</attribute3_defaultvalue>
+        <attribute3_required></attribute3_required>
+        <attribute3_disabled></attribute3_disabled>
+        <attribute4_attributeid>5cc09402adccf621f8021959</attribute4_attributeid>
+        <attribute4_name>Date</attribute4_name>
+        <attribute4_description></attribute4_description>
+        <attribute4_type>5</attribute4_type>
+        <attribute4_defaultvalue>2019-04-03 00:00:00</attribute4_defaultvalue>
+        <attribute4_required></attribute4_required>
+        <attribute4_disabled></attribute4_disabled>
+        <attribute5_attributeid>5cc09402adccf621f802195a</attribute5_attributeid>
+        <attribute5_name>Select</attribute5_name>
+        <attribute5_description></attribute5_description>
+        <attribute5_type>6</attribute5_type>
+        <attribute5_defaultvalue>A</attribute5_defaultvalue>
+        <attribute5_required></attribute5_required>
+        <attribute5_disabled></attribute5_disabled>
+        <attribute5_predefinedvalue0>A</attribute5_predefinedvalue0>
+        <attribute5_predefinedvalue1>B</attribute5_predefinedvalue1>
+        <attribute5_predefinedvalue2>C</attribute5_predefinedvalue2>
+        <attribute5_predefinedvalues_total>3</attribute5_predefinedvalues_total>
+        <attribute6_attributeid>5cc09402adccf621f802195b</attribute6_attributeid>
+        <attribute6_name>Array</attribute6_name>
+        <attribute6_description></attribute6_description>
+        <attribute6_type>7</attribute6_type>
+        <attribute6_defaultvalue>a,b,c,d</attribute6_defaultvalue>
+        <attribute6_required></attribute6_required>
+        <attribute6_disabled></attribute6_disabled>
+        <attributes_total>7</attributes_total>
+        <user0_name>user1</user0_name>
+        <user0_read>1</user0_read>
+        <user0_write>1</user0_write>
+        <users_total>1</users_total>
+        <group0_id>55557777bbbbccccddddaaaa</group0_id>
+        <group0_name>EVERYONE</group0_name>
+        <group0_read>1</group0_read>
+        <group0_write>1</group0_write>
+        <groups_total>1</groups_total>
+        <path0>/user1</path0>
+        <paths_total>1</paths_total>
+    </metadataset>
+</metadatasets>
+RESPONSE;
+
+    }
+}

--- a/tests/CloudApi/RemoveSetFromFileObjectTest.php
+++ b/tests/CloudApi/RemoveSetFromFileObjectTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace CodeLathe\FileCloudApi\Tests\CloudApi;
+
+use codelathe\fccloudapi\CloudAPI;
+use codelathe\fccloudapi\CommandRecord;
+use CodeLathe\FileCloudApi\Tests\Fixtures\AccessibleCloudApi;
+use PHPUnit\Framework\TestCase;
+
+class RemoveSetFromFileObjectTest extends TestCase
+{
+    public function testOnSuccess()
+    {
+        $serverUrl = 'https://fcapi.example.com';
+        $cloudApiMock = $this->getMockBuilder(AccessibleCloudApi::class)
+            ->setConstructorArgs([$serverUrl])
+            ->setMethods(['init', '__destruct', 'doPost'])
+            ->getMock();
+
+        $mockApiResponse = <<<RESPONSE
+<commands>
+    <command>
+        <type>removesetfromfileobject</type>
+        <result>1</result>
+        <message>Metadata set (setId: 5ccafe12adccf621f80342e6) was successfully removed for File Object (/tester/textfile1.txt)</message>
+    </command>
+</commands>
+RESPONSE;
+        $mockApiRequest = $this->getValidApiRequest();
+
+        $cloudApiMock->method('doPost')
+            ->with("{$serverUrl}/core/removesetfromfileobject", http_build_query($mockApiRequest))
+            ->willReturn($mockApiResponse);
+
+        /** @var CloudAPI $cloudApiMock */
+        /** @var CommandRecord $commandRecord */
+        $commandRecord = $cloudApiMock->removeSetFromFileObject(...array_values($mockApiRequest));
+        $this->assertEquals(1, $commandRecord->getResult());
+        $this->assertEquals('removesetfromfileobject', $commandRecord->getType());
+        $this->assertEquals(
+            'Metadata set (setId: 5ccafe12adccf621f80342e6) was successfully removed for File Object (/tester/textfile1.txt)',
+            $commandRecord->getMessage()
+        );
+    }
+
+    public function testOnFailure()
+    {
+        $serverUrl = 'https://fcapi.example.com';
+        $cloudApiMock = $this->getMockBuilder(AccessibleCloudApi::class)
+            ->setConstructorArgs([$serverUrl])
+            ->setMethods(['init', '__destruct', 'doPost'])
+            ->getMock();
+
+        $mockApiResponse = <<<RESPONSE
+<commands>
+    <command>
+        <type>removesetfromfileobject</type>
+        <result>0</result>
+        <message>Failed to remove Set Definition (setId: 5ccafe12adccf621f80342e7) for File Object (/tester/textfile1.txt). Reason: Incorrect set id provided</message>
+    </command>
+</commands>
+RESPONSE;
+        $mockApiRequest = $this->getValidApiRequest();
+        $mockApiRequest['setid'] = '5ccafe12adccf621f80342e7';    // Pretend this is an invalid id
+
+
+        $cloudApiMock->method('doPost')
+            ->with("{$serverUrl}/core/removesetfromfileobject", http_build_query($mockApiRequest))
+            ->willReturn($mockApiResponse);
+
+        /** @var CloudAPI $cloudApiMock */
+        /** @var CommandRecord $commandRecord */
+        $commandRecord = $cloudApiMock->removeSetFromFileObject(...array_values($mockApiRequest));
+        $this->assertEquals(0, $commandRecord->getResult());
+        $this->assertEquals('removesetfromfileobject', $commandRecord->getType());
+        $this->assertEquals(
+            'Failed to remove Set Definition (setId: 5ccafe12adccf621f80342e7) for File Object (/tester/textfile1.txt). Reason: Incorrect set id provided',
+            $commandRecord->getMessage()
+        );
+    }
+
+    private function getValidApiRequest()
+    {
+        return [
+            'fullpath' => '/tester/textfile1.txt',
+            'setid' => '5ccafe12adccf621f80342e6',
+        ];
+    }
+}

--- a/tests/CloudApi/SaveAttributeValuesTest.php
+++ b/tests/CloudApi/SaveAttributeValuesTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace CodeLathe\FileCloudApi\Tests\CloudApi;
+
+use codelathe\fccloudapi\CloudAPI;
+use codelathe\fccloudapi\CommandRecord;
+use CodeLathe\FileCloudApi\Tests\Fixtures\AccessibleCloudApi;
+use PHPUnit\Framework\TestCase;
+
+class SaveAttributeValuesTest extends TestCase
+{
+    /**
+     * Test whether it returns the correct data record for
+     * a successful API request.
+     */
+    public function testOnSuccess()
+    {
+        $serverUrl = 'https://fcapi.example.com';
+        $cloudApiMock = $this->getMockBuilder(AccessibleCloudApi::class)
+            ->setConstructorArgs([$serverUrl])
+            ->setMethods(['init', '__destruct', 'doPost'])
+            ->getMock();
+
+        $mockApiResponse = <<<RESPONSE
+<commands>
+    <command>
+        <type>saveattributevalues</type>
+        <result>1</result>
+        <message>Attribute values saved successfully (setId: 5ccafe12adccf621f80342e6 | fullpath: /tester/textfile1.txt)!</message>
+    </command>
+</commands>
+RESPONSE;
+        $mockApiRequest = $this->getValidApiRequest();
+
+        $cloudApiMock->method('doPost')
+            ->with("{$serverUrl}/core/saveattributevalues", http_build_query($mockApiRequest))
+            ->willReturn($mockApiResponse);
+
+        /** @var CloudAPI $cloudApiMock */
+        /** @var CommandRecord $commandRecord */
+        $commandRecord = $cloudApiMock->saveAttributeValues(...array_values($this->getWrapperArguments()));
+        $this->assertEquals(1, $commandRecord->getResult());
+        $this->assertEquals('saveattributevalues', $commandRecord->getType());
+        $this->assertEquals('Attribute values saved successfully (setId: 5ccafe12adccf621f80342e6 | fullpath: /tester/textfile1.txt)!', $commandRecord->getMessage());
+    }
+
+    /**
+     * Test whether it returns the correct data record for
+     * an unsuccessful API request.
+     */
+    public function testInvalidSetId()
+    {
+        $serverUrl = 'https://fcapi.example.com';
+        $cloudApiMock = $this->getMockBuilder(AccessibleCloudApi::class)
+            ->setConstructorArgs([$serverUrl])
+            ->setMethods(['init', '__destruct', 'doPost'])
+            ->getMock();
+
+        $mockApiResponse = <<<RESPONSE
+<commands>
+    <command>
+        <type>saveattributevalues</type>
+        <result>0</result>
+        <message>Failed to save attribute values. Reason: Incorrect set id provided</message>
+    </command>
+</commands>
+RESPONSE;
+        $mockApiRequest = $this->getValidApiRequest();
+        $mockApiRequest['setid'] = '5ccafe12adccf621f80342e7';  // Pretend this is invalid/dne
+
+
+        $cloudApiMock->method('doPost')
+            ->with("{$serverUrl}/core/saveattributevalues", http_build_query($mockApiRequest))
+            ->willReturn($mockApiResponse);
+
+        $arguments = $this->getWrapperArguments();
+        $arguments['setid'] = '5ccafe12adccf621f80342e7';   // Pretend this is invalid/dne
+
+        /** @var CloudAPI $cloudApiMock */
+        /** @var CommandRecord $commandRecord */
+        $commandRecord = $cloudApiMock->saveAttributeValues(...array_values($arguments));
+        $this->assertEquals(0, $commandRecord->getResult());
+        $this->assertEquals('saveattributevalues', $commandRecord->getType());
+        $this->assertEquals(
+            'Failed to save attribute values. Reason: Incorrect set id provided',
+            $commandRecord->getMessage()
+        );
+    }
+
+    private function getWrapperArguments()
+    {
+        return [
+            'fullpath' => '/tester/textfile1.txt',
+            'setid' => '5ccafe12adccf621f80342e6',
+            'attributes' => [
+                0 => [
+                    'attributeid' => '5ccafe12adccf621f80342df',
+                    'value' => 'Default',
+                ],
+                1 => [
+                    'attributeid' => '5ccafe12adccf621f80342e0',
+                    'value' => '100',
+                ],
+                2 => [
+                    'attributeid' => '5ccafe12adccf621f80342e1',
+                    'value' => '1.1',
+                ],
+                3 => [
+                    'attributeid' => '5ccafe12adccf621f80342e2',
+                    'value' => 'false',
+                ],
+                4 => [
+                    'attributeid' => '5ccafe12adccf621f80342e3',
+                    'value' => '2019-04-03 00:00:00',
+                ],
+                5 => [
+                    'attributeid' => '5ccafe12adccf621f80342e4',
+                    'value' => 'foo',
+                ],
+                6 => [
+                    'attributeid' => '5ccafe12adccf621f80342e5',
+                    'value' => 'a,b,c,d',
+                ],
+            ]
+        ];
+    }
+    
+    /**
+     * 
+     */
+    private function getValidApiRequest()
+    {
+        return [
+            'fullpath' => '/tester/textfile1.txt',
+            'setid' => '5ccafe12adccf621f80342e6',
+            'attribute0_attributeid' => '5ccafe12adccf621f80342df',
+            'attribute0_value' => 'Default',
+            'attribute1_attributeid' => '5ccafe12adccf621f80342e0',
+            'attribute1_value' => '100',
+            'attribute2_attributeid' => '5ccafe12adccf621f80342e1',
+            'attribute2_value' => '1.1',
+            'attribute3_attributeid' => '5ccafe12adccf621f80342e2',
+            'attribute3_value' => 'false',
+            'attribute4_attributeid' => '5ccafe12adccf621f80342e3',
+            'attribute4_value' => '2019-04-03 00:00:00',
+            'attribute5_attributeid' => '5ccafe12adccf621f80342e4',
+            'attribute5_value' => 'foo',
+            'attribute6_attributeid' => '5ccafe12adccf621f80342e5',
+            'attribute6_value' => 'a,b,c,d',
+            'attributes_total' => '7'
+        ];
+    }
+}


### PR DESCRIPTION
Adds wrappers for:

- [x] getmetadatasetsforsearch
- [x] addsettofileobject
- [x] removesetfromfileobject
- [x] saveattributevalues

Areas of interest:
- [Type guessing logic](https://github.com/codelathe/filecloudapi-php/pull/14/files#diff-05d58a3a8cb1f77374f9f5c94039d036R238)
- Wrapper methods:
    - [getMetadataSetsForSearch](https://github.com/codelathe/filecloudapi-php/pull/14/files#diff-05d58a3a8cb1f77374f9f5c94039d036R4658)
    - [addSetToFileObject](https://github.com/codelathe/filecloudapi-php/pull/14/files#diff-05d58a3a8cb1f77374f9f5c94039d036R4677)
    - [removeSetFromFileObject](https://github.com/codelathe/filecloudapi-php/pull/14/files#diff-05d58a3a8cb1f77374f9f5c94039d036R4699)
    - [saveAttributeValues](https://github.com/codelathe/filecloudapi-php/pull/14/files#diff-05d58a3a8cb1f77374f9f5c94039d036R4722)