### PR TITLE
Fixed the linebreak problem on debug mode.

### DIFF
--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -2558,6 +2558,9 @@ class APICore {
     {
         if ($this->debug) {
 
+            // normalize the line breaks
+            $result = str_replace('\r\n', '\n', trim($result));
+
             // request
             $this->debugMessages['Request'] = "$method $url";
             $body = [];
@@ -2566,7 +2569,8 @@ class APICore {
 
             // request headers
             $rawRequest = curl_getinfo($this->curl_handle, CURLINFO_HEADER_OUT);
-            $lines = explode(PHP_EOL, trim($rawRequest));
+            $rawRequest = str_replace('\r\n', '\n', trim($rawRequest));
+            $lines = explode('\n', trim($rawRequest));
             array_shift($lines); // remove the first line and keep the headers
             $headers = [];
             foreach ($lines as $line) {
@@ -2588,8 +2592,8 @@ class APICore {
             $this->debugMessages['Response Code'] = curl_getinfo($this->curl_handle, CURLINFO_HTTP_CODE);
 
             // Response Headers and body
-            [$rawHeaders, $body] = explode(PHP_EOL . PHP_EOL, $result);
-            $lines = explode(PHP_EOL, trim($rawHeaders));
+            [$rawHeaders, $body] = explode('\n\n', $result);
+            $lines = explode('\n', trim($rawHeaders));
             array_shift($lines);
             $headers = [];
             foreach ($lines as $line) {

--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -2570,7 +2570,7 @@ class APICore {
             // request headers
             $rawRequest = curl_getinfo($this->curl_handle, CURLINFO_HEADER_OUT);
             $rawRequest = str_replace('\r\n', '\n', trim($rawRequest));
-            $lines = explode('\n', trim($rawRequest));
+            $lines = explode('\n', $rawRequest);
             array_shift($lines); // remove the first line and keep the headers
             $headers = [];
             foreach ($lines as $line) {


### PR DESCRIPTION
* Replaced the `PHP_EOL . PHP_EOL` with `\n\n`.
* Included a little logic to normalize the line breaks to be always `\n`.