### PR TITLE
Fix debug mode for redirects

### DIFF
--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -2623,6 +2623,15 @@ class APICore {
             $this->debugMessages['Response Code'] = curl_getinfo($this->curl_handle, CURLINFO_HTTP_CODE);
 
             // Response Headers and body
+
+            // removing 100 and redirect responses
+            $regex = '/^HTTP\/[0-9.]+ [13][0-9]{2} [A-Z][a-z]+/';
+            while (preg_match($regex, $result)) {
+                $result = preg_replace($regex, '', $result);
+                $result = trim($result);
+            }
+
+            // splitting headers and body
             [$rawHeaders, $body] = explode("\n\n", $result, 2);
             $lines = explode("\n", trim($rawHeaders));
             array_shift($lines);

--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -2632,7 +2632,12 @@ class APICore {
             }
 
             // splitting headers and body
-            [$rawHeaders, $body] = explode("\n\n", $result, 2);
+            if (strpos($result, "\n\n") === false) { // requests with no body
+                $rawHeaders = $result;
+                $body = '';
+            } else {
+                [$rawHeaders, $body] = explode("\n\n", $result, 2);
+            }
             $lines = explode("\n", trim($rawHeaders));
             array_shift($lines);
             $headers = [];


### PR DESCRIPTION
* On debug mode, fixed the headers and body splitting when the response contains redirections or 100 responses.