### PR TITLE
Return all share records

### DIFF
--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -4478,7 +4478,7 @@ class CloudAPI extends APICore {
         $collection = new Collection($buffer,  "share", ShareRecord::class);
         $this->stopTimer();
        if ($collection->getNumberOfRecords() > 0)
-            return $collection->getRecords()[0];
+            return $collection->getRecords();
         return NULL;
     } 
     


### PR DESCRIPTION
Currently, only first item is returned which does not reflect the actual API response.