### PR TITLE
Return all user access records

### DIFF
--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -4490,7 +4490,7 @@ class CloudAPI extends APICore {
         $collection = new Collection($buffer,  "user", UserAcessForShareRecord::class);
         $this->stopTimer();
         if ($collection->getNumberOfRecords() > 0)
-            return $collection->getRecords()[0];
+            return $collection->getRecords();
         return NULL;
     } 
      public function getUsersForShare($shareid) {


### PR DESCRIPTION
Returning only the first element does not reflect the actual api response (which returns all users with access)