### PR TITLE
Return all users in share

### DIFF
--- a/fccloudapi.php
+++ b/fccloudapi.php
@@ -4494,7 +4494,7 @@ class CloudAPI extends APICore {
         $collection = new Collection($buffer,  "user", UsersForShareRecord::class);
         $this->stopTimer();
         if ($collection->getNumberOfRecords() > 0)
-            return $collection->getRecords()[0];
+            return $collection->getRecords();
         return NULL;
     }
     


### PR DESCRIPTION
Returning a single user does not reflect the actual API response